### PR TITLE
Version Solving Error Fix

### DIFF
--- a/lib/src/awesome_snackbar_content.dart
+++ b/lib/src/awesome_snackbar_content.dart
@@ -32,9 +32,17 @@ class AwesomeSnackbarContent extends StatelessWidget {
   /// if you want to use this in materialBanner
   final bool inMaterialBanner;
 
+  /// if you want to customize the font size of the title
+  final double? titleFontSize;
+
+  /// if you want to customize the font size of the message
+  final double? messageFontSize;
+
   const AwesomeSnackbarContent({
     Key? key,
     this.color,
+    this.titleFontSize,
+    this.messageFontSize,
     required this.title,
     required this.message,
     required this.contentType,
@@ -76,7 +84,8 @@ class AwesomeSnackbarContent extends StatelessWidget {
     } else if (isTablet) {
       leftSpace = size.width * 0.05;
       horizontalPadding = size.width * 0.2;
-    } else if (isDesktop) { // else {
+    } else if (isDesktop) {
+      // else {
       leftSpace = size.width * 0.05;
       horizontalPadding = size.width * 0.3;
     }
@@ -170,9 +179,10 @@ class AwesomeSnackbarContent extends StatelessWidget {
                       child: Text(
                         title,
                         style: TextStyle(
-                          fontSize: !isMobile
-                              ? size.height * 0.03
-                              : size.height * 0.025,
+                          fontSize: titleFontSize ??
+                              (!isMobile
+                                  ? size.height * 0.03
+                                  : size.height * 0.025),
                           fontWeight: FontWeight.w600,
                           color: Colors.white,
                         ),
@@ -205,7 +215,7 @@ class AwesomeSnackbarContent extends StatelessWidget {
                   child: Text(
                     message,
                     style: TextStyle(
-                      fontSize: size.height * 0.016,
+                      fontSize: messageFontSize ?? size.height * 0.016,
                       color: Colors.white,
                     ),
                   ),

--- a/lib/src/awesome_snackbar_content.dart
+++ b/lib/src/awesome_snackbar_content.dart
@@ -3,6 +3,7 @@ import 'package:awesome_snackbar_content/src/content_type.dart';
 import 'package:awesome_snackbar_content/utils/languages.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'dart:ui' as ui;
 
 class AwesomeSnackbarContent extends StatelessWidget {
   /// `IMPORTANT NOTE` for SnackBar properties before putting this in `content`
@@ -75,7 +76,7 @@ class AwesomeSnackbarContent extends StatelessWidget {
     } else if (isTablet) {
       leftSpace = size.width * 0.05;
       horizontalPadding = size.width * 0.2;
-    } else {
+    } else if (isDesktop) { // else {
       leftSpace = size.width * 0.05;
       horizontalPadding = size.width * 0.3;
     }
@@ -110,7 +111,8 @@ class AwesomeSnackbarContent extends StatelessWidget {
                 AssetsPath.bubbles,
                 height: size.height * 0.06,
                 width: size.width * 0.05,
-                color: hslDark.toColor(),
+                colorFilter:
+                    _getColorFilter(hslDark.toColor(), ui.BlendMode.srcIn),
                 package: 'awesome_snackbar_content',
               ),
             ),
@@ -132,7 +134,8 @@ class AwesomeSnackbarContent extends StatelessWidget {
                 SvgPicture.asset(
                   AssetsPath.back,
                   height: size.height * 0.06,
-                  color: hslDark.toColor(),
+                  colorFilter:
+                      _getColorFilter(hslDark.toColor(), ui.BlendMode.srcIn),
                   package: 'awesome_snackbar_content',
                 ),
                 Positioned(
@@ -236,4 +239,8 @@ class AwesomeSnackbarContent extends StatelessWidget {
       return AssetsPath.failure;
     }
   }
+
+  static ColorFilter? _getColorFilter(
+          ui.Color? color, ui.BlendMode colorBlendMode) =>
+      color == null ? null : ui.ColorFilter.mode(color, colorBlendMode);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  flutter_svg: ^1.0.3
+  flutter_svg: ^2.0.4
 
   flutter:
     sdk: flutter


### PR DESCRIPTION
## Fix for the version solving error

### Error
`Because every version of awesome_snackbar_content depends on flutter_svg ^1.0.3 and [app] depends on flutter_svg ^2.0.0+1, awesome_snackbar_content is forbidden.`

### Changes made
- Upgraded flutter_svg package to its latest.
- Gave the deprecated color property (of flutter_svg) another simple solution.
- Also added the ability for the user to customise the font sizes for both the title and message texts (as Optional Parameters).