### PR TITLE
reduced the top value of icon

### DIFF
--- a/lib/src/awesome_snackbar_content.dart
+++ b/lib/src/awesome_snackbar_content.dart
@@ -115,7 +115,7 @@ class AwesomeSnackbarContent extends StatelessWidget {
 
           // Bubble Icon
           Positioned(
-            top: -size.height * 0.02,
+            top: -size.height * 0.015,
             left: !isRTL
                 ? leftSpace -
                     8 -


### PR DESCRIPTION
## Changes Proposed

- Reduced the `top` value in `Positioned` widget

## Issue (if any)
Link to issue which this PR is resolving
- #34 

## Checklist

- [x] Tested on multiplatform (web, tablet, mobile views)
- [x] No commented code
- [x] No `print` statement left

## Gif (if applicable)

## Screenshots
Add screenshot of following views for the changes you've made.

### Desktop
<img width="1420" alt="Screenshot 2024-09-06 at 2 39 07 PM" src="https://github.com/user-attachments/assets/76d601a7-ed4e-4add-adbb-29ce24b34d6e">

### Tablet
<img width="729" alt="Screenshot 2024-09-06 at 2 39 16 PM" src="https://github.com/user-attachments/assets/f3fb1e4b-cba6-44c8-bc6a-c00b10285486">

### Mobile
<img width="468" alt="Screenshot 2024-09-06 at 2 39 28 PM" src="https://github.com/user-attachments/assets/258f36ce-79c3-453a-ab35-4afa6d3b6daf">
