### PR TITLE
Stop strong SDK constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.7
 homepage: https://github.com/mhmzdev/awesome_snackbar_content
 
 environment:
-  sdk: 3.8.1
+  sdk: ^3.8.1
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
This package is needlessly (I think) pinned to 3.8.1, which prevents it from running on the latest SDK.  

This loosens the restraint.
